### PR TITLE
fix assignment error in struct resnet

### DIFF
--- a/src/resnet.cpp
+++ b/src/resnet.cpp
@@ -194,7 +194,7 @@ struct ResNet : torch::nn::Module
                 "three elements."};
         }
 
-        m_groups = m_groups;
+        m_groups = groups;
         m_base_width = width_per_group;
 
         m_conv1 = register_module(


### PR DESCRIPTION
`m_groups = m_groups;` shoud be `m_groups = groups;`